### PR TITLE
Allow CSV format for Jasper reports

### DIFF
--- a/src/Douglas/Request/Report.php
+++ b/src/Douglas/Request/Report.php
@@ -9,6 +9,7 @@ class Report
     const FORMAT_XLS = 'xls';
     const FORMAT_DOCX = 'docx';
     const FORMAT_XLSX = 'xlsx';
+    const FORMAT_CSV = 'csv';
 
     public $jasper_url;
     public $report_url;
@@ -152,6 +153,7 @@ class Report
             self::FORMAT_PDF,
             self::FORMAT_DOCX,
             self::FORMAT_XLSX,
+            self::FORMAT_CSV,
         );
         if (!in_array($format, $allowed_formats)) {
             throw new \Exception(

--- a/tests/Douglas/Tests/Request/ReportTest.php
+++ b/tests/Douglas/Tests/Request/ReportTest.php
@@ -32,7 +32,13 @@ class ReportTest extends \PHPUnit_Framework_TestCase
     {
         $valid_format = \Douglas\Request\Report::getFormat('XLSX');
         $this->assertEquals('xlsx', $valid_format);
-    }    
+    }
+    
+    public function testCsvIsValidFormat()
+    {
+        $valid_format = \Douglas\Request\Report::getFormat('CSV');
+        $this->assertEquals('csv', $valid_format);
+    }  
 
     public function testInvalidFormats()
     {
@@ -40,7 +46,7 @@ class ReportTest extends \PHPUnit_Framework_TestCase
             $valid_format = \Douglas\Request\Report::getFormat('PHP');
         } catch (\Exception $expected) {
             $this->assertEquals(
-                "Invalid format php.  Needs to be one of these: html, xls, pdf, docx, xlsx.",
+                "Invalid format php.  Needs to be one of these: html, xls, pdf, docx, xlsx, csv.",
                 $expected->getMessage()
             );
 


### PR DESCRIPTION
Here is the purposed change for Douglas to allow CSV format for Jasper reports.